### PR TITLE
Add 'Open with Codeanywhere' badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <a href="https://vercel.com/new/clone?repository-url=https://github.com/SJFCS/cloudnative.love/tree/main&project-name=cloudnative.love&repo-name=cloudnative.love" rel="nofollow"><img src="https://vercel.com/button"></a>
 <a href="https://app.netlify.com/start/deploy?repository=https://github.com/SJFCS/cloudnative.love" rel="nofollow"><img src="https://www.netlify.com/img/deploy/button.svg"></a>
 <a href="https://stackblitz.com/github/SJFCS/cloudnative.love" rel="nofollow"><img src="https://developer.stackblitz.com/img/open_in_stackblitz.svg"></a>
+<a href="https://app.codeanywhere.com/#https://github.com/SJFCS/cloudnative.love/blob/912fca778a4969362cc1bb248cc547b9c2803492/README.md" rel="nofollow"><img src="https://codeanywhere.com/img/open-in-codeanywhere-btn.svg"></a>
 </p>
 
 This Wiki is used to organize and record various technical knowledge and practices related to DevOps technology.


### PR DESCRIPTION
With Codeanywhere, developers and contributors can instantly launch a cloud or local IDE with a pre-configured remote development environment. One can work in the cloud or locally, and it ensures all contributors have access to the same, ready-to-use dev env.